### PR TITLE
Simple changes in WiFriedManager.m and WiFriedHelperX

### DIFF
--- a/WiFriedXApp/WiFriedManager.m
+++ b/WiFriedXApp/WiFriedManager.m
@@ -269,6 +269,7 @@ static void callback(SCDynamicStoreRef store, CFArrayRef changedKeys, void* info
         if (!result)
         {
             error = CFBridgingRelease(cfError);
+            NSLog(@"Could not perform JobBless: %@", error.localizedDescription);
         }
     }
     

--- a/WiFriedXApp/WiFriedManager.m
+++ b/WiFriedXApp/WiFriedManager.m
@@ -24,8 +24,11 @@ static WiFriedManager* sharedManager = nil;
 
 + (WiFriedManager*) sharedInstance
 {
-    if (sharedManager == nil)
-         sharedManager = [[WiFriedManager alloc] init];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedManager = [[WiFriedManager alloc] init];
+    });
+
     return sharedManager;
 }
 

--- a/WiFriedXHelper/WiFriedXHelper.m
+++ b/WiFriedXHelper/WiFriedXHelper.m
@@ -34,7 +34,7 @@
 
 bool setAWDLIFUp(bool up);
 void SocketAcceptCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void *data, void *info);
-void selfDestructIfNeeded();
+void selfDestructIfNeeded(void);
 
 
 


### PR DESCRIPTION
Hi, just did a bit of code cleanup here to silence some static analyzer and compiler warnings. I also changed the sharedInstance method of WiFriedManager to use the dispatch_once pattern as that's what Apple recommends.

Thanks,
Josh
